### PR TITLE
(fix) allow event listener reattach after unmount

### DIFF
--- a/client/actions/menu.js
+++ b/client/actions/menu.js
@@ -36,4 +36,9 @@ export function makeMenu () {
       allFriends[i].addEventListener('contextmenu', listener);
     }
   }
+
+}
+
+export function reattachMenus () {
+  menuRendered = false;
 }

--- a/client/components/friendsList.js
+++ b/client/components/friendsList.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router';
 import { inviteToSession, makeSession, sessionChange, makePrivateSession, askSecondUserToJoin } from '../actions/session';
 import socket from '../sync';
 import io from 'socket.io-client';
-import { makeMenu } from '../actions/menu';
+import { makeMenu, reattachMenus } from '../actions/menu';
 import { addFriend, getAllFriends } from '../actions/friends';
 const ipcRenderer = window.require('electron').ipcRenderer;
 
@@ -27,6 +27,10 @@ class FriendsList extends React.Component {
 
   componentDidUpdate () {
     makeMenu();
+  }
+
+  componentWillUnmount () {
+    reattachMenus();
   }
 
   addPerson (e) {


### PR DESCRIPTION
// removed the block on new event listener after component has unmounted
// allows user to enter a session, leave, and choose a new session